### PR TITLE
Fixed the SVG in CraftBook's link not working

### DIFF
--- a/links/craftbook.json
+++ b/links/craftbook.json
@@ -1,6 +1,6 @@
 {
     "Description": "CraftBook lets you create magically extending bridges, compact Redstone circuits, complex Minecart mechanics, and much more — all without a client mod and fully customizable by the server.",
-    "img": "https://enginehub.org/static/craftbook-logo.06bf470a.svg",
+    "img": "https://media.forgecdn.net/avatars/thumbnails/66/772/62/62/636163073441863791.png",
     "Bukkit": "https://dev.bukkit.org/projects/craftbook",
     "GitHub": "https://github.com/EngineHub/CraftBook",
     "Docs": "https://craftbook.enginehub.org/en/3.x/",


### PR DESCRIPTION
Discord doesn't like SVGs, use a PNG instead