### PR TITLE
Update links for EssentialsX

### DIFF
--- a/links/essentialsx.json
+++ b/links/essentialsx.json
@@ -3,7 +3,8 @@
     "img": "https://www.spigotmc.org/data/resource_icons/9/9089.jpg",
     "Spigot": "https://www.spigotmc.org/resources/9089/",
     "GitHub": "https://github.com/EssentialsX/Essentials",
-    "Wiki": "https://github.com/EssentialsX/Essentials/wiki",
+    "Website": "https://essentialsx.net",
+    "Wiki": "https://essentialsx.net/wiki/Home.html",
     "Permissions list": "https://essinfo.xeya.me/permissions.php",
     "Commands list": "https://essinfo.xeya.me/commands.php",
     "Placeholders": "https://github.com/PlaceholderAPI/PlaceholderAPI/wiki/Placeholders#essentials"


### PR DESCRIPTION
Updated Wiki link to https://essentialsx.net/wiki/Home.html and added Website with https://essentialsx.net as value